### PR TITLE
Fixes missing parenthesis and mismatched lock file version

### DIFF
--- a/lib/ueberauth/strategy/twitter.ex
+++ b/lib/ueberauth/strategy/twitter.ex
@@ -60,7 +60,7 @@ defmodule Ueberauth.Strategy.Twitter do
   Includes the credentials from the twitter response.
   """
   def credentials(conn) do
-    {token, _secret} = get_session(conn, :twitter_token
+    {token, _secret} = get_session(conn, :twitter_token)
 
     %Credentials{token: token}
   end

--- a/mix.lock
+++ b/mix.lock
@@ -9,7 +9,7 @@
   "oauth": {:git, "https://github.com/tim/erlang-oauth.git", "cd31addc828179983564fd57738f1680a4a4d1ff", []},
   "oauth2": {:hex, :oauth2, "0.5.0"},
   "oauther": {:hex, :oauther, "1.0.2"},
-  "plug": {:hex, :plug, "1.0.2"},
+  "plug": {:hex, :plug, "1.0.3"},
   "poison": {:hex, :poison, "1.5.0"},
   "ssl_verify_hostname": {:hex, :ssl_verify_hostname, "1.0.5"},
-  "ueberauth": {:hex, :ueberauth, "0.1.0"}}
+  "ueberauth": {:hex, :ueberauth, "0.2.0"}}


### PR DESCRIPTION
This module never compiled, has always been missing the parenthesis. Weird that nobody has patched it for fixed it. Either way, here you go!
