### PR TITLE
fix Credentials (oauth_token, oauth_token_secret)

### DIFF
--- a/lib/ueberauth/strategy/twitter.ex
+++ b/lib/ueberauth/strategy/twitter.ex
@@ -60,9 +60,9 @@ defmodule Ueberauth.Strategy.Twitter do
   Includes the credentials from the twitter response.
   """
   def credentials(conn) do
-    {token, _secret} = get_session(conn, :twitter_token)
+    {token, secret} = conn.private.twitter_token
 
-    %Credentials{token: token}
+    %Credentials{token: token, secret: secret}
   end
 
   @doc """


### PR DESCRIPTION
Populates the `Credentials` struct with the oauth_token/oauth_token_secret (mirrors [omniauth-twitter](https://github.com/arunagw/omniauth-twitter/tree/343120bf99b5dbe0515f651e82ba128609ce1a13#authentication-hash))
