### PR TITLE
Improve OAuth error handling

### DIFF
--- a/lib/ueberauth/strategy/twitter/oauth.ex
+++ b/lib/ueberauth/strategy/twitter/oauth.ex
@@ -81,6 +81,8 @@ defmodule Ueberauth.Strategy.Twitter.OAuth do
 
     {:ok, {token, token_secret}}
   end
+  defp decode_access_response({:ok, {{_, status_code, status_description}, _, _}}), do: {:error, "#{status_code} - #{status_description}"}
+  defp decode_access_response({:error, {error, [_, {:inet, [:inet], error_reason}]}}), do: {:error, "#{error}: #{error_reason}"}
   defp decode_access_response(error), do: {:error, error}
 
   defp decode_request_response({:ok, {{_, 200, _}, _, _} = resp}) do
@@ -90,6 +92,8 @@ defmodule Ueberauth.Strategy.Twitter.OAuth do
 
     {:ok, {token, token_secret}}
   end
+  defp decode_request_response({:ok, {{_, status_code, status_description}, _, _}}), do: {:error, "#{status_code} - #{status_description}"}
+  defp decode_request_response({:error, {error, [_, {:inet, [:inet], error_reason}]}}), do: {:error, "#{error}: #{error_reason}"}
   defp decode_request_response(error), do: {:error, error}
 
   defp endpoint("/" <> _path = endpoint, client), do: client.site <> endpoint
@@ -100,7 +104,7 @@ defmodule Ueberauth.Strategy.Twitter.OAuth do
       client
       |> Map.get(endpoint, endpoint)
       |> endpoint(client)
-    
+
     endpoint =
       if params do
         endpoint <> "?" <> URI.encode_query(params)

--- a/test/strategy/twitter/oauth_test.exs
+++ b/test/strategy/twitter/oauth_test.exs
@@ -1,0 +1,36 @@
+defmodule Ueberauth.Strategy.Twitter.OAuthTest do
+  use ExUnit.Case, async: true
+
+  alias Ueberauth.Strategy.Twitter.OAuth
+
+  setup do
+    Application.put_env :ueberauth, OAuth,
+      consumer_key: "consumer_key",
+      consumer_secret: "consumer_secret"
+    :ok
+  end
+
+  test "access_token!/2: raises an appropriate error on auth failure" do
+    assert_raise RuntimeError, ~r/401/i, fn ->
+      OAuth.access_token! {"badtoken", "badsecret"}, "badverifier"
+    end
+  end
+
+  test "access_token!/2 raises an appropriate error on network failure" do
+    assert_raise RuntimeError, ~r/nxdomain/i, fn ->
+      OAuth.access_token! {"token", "secret"}, "verifier", site: "https://bogusapi.twitter.com"
+    end
+  end
+
+  test "request_token!/2: raises an appropriate error on auth failure" do
+    assert_raise RuntimeError, ~r/401/i, fn ->
+      OAuth.request_token! [], redirect_uri: "some/uri"
+    end
+  end
+
+  test "request_token!/2: raises an appropriate error on network failure" do
+    assert_raise RuntimeError, ~r/nxdomain/i, fn ->
+      OAuth.request_token! [], site: "https://bogusapi.twitter.com", redirect_uri: "some/uri"
+    end
+  end
+end


### PR DESCRIPTION
- Fixes a crash on network error in access_token!/2 and request_token!/2
- Fixes a crash when an API request results in a non-200 status

Ideally this would raise an error-specific exception instead of the default `RuntimeError` but I think it's best to err on the side of backwards-compatibility. I've also created a test for `OAuth` that only tests for this issue but which could (should :wink:) include more extensive tests in the future.

Fixes #8 
