### PR TITLE
Add location to Info

### DIFF
--- a/lib/ueberauth/strategy/twitter.ex
+++ b/lib/ueberauth/strategy/twitter.ex
@@ -77,6 +77,7 @@ defmodule Ueberauth.Strategy.Twitter do
       name: user["name"],
       nickname: user["screen_name"],
       description: user["description"],
+      location: user["location"],
       urls: %{
         Twitter: "https://twitter.com/#{user["screen_name"]}",
         Website: user["url"]


### PR DESCRIPTION
This is a trivial change (1 line) that adds Twitter's "location" to Ueberauth's Info struct.