### PR TITLE
Change the Info image to be https instead of http

### DIFF
--- a/lib/ueberauth/strategy/twitter.ex
+++ b/lib/ueberauth/strategy/twitter.ex
@@ -73,7 +73,7 @@ defmodule Ueberauth.Strategy.Twitter do
 
     %Info{
       email: user["email"],
-      image: user["profile_image_url"],
+      image: user["profile_image_url_https"],
       name: user["name"],
       nickname: user["screen_name"],
       description: user["description"],


### PR DESCRIPTION
I feel like we should use https as much as we can instead of http. I would like to suggest to use the https version of the profile image instead of the http version.