### PR TITLE
More descriptive error message on OAuth request_token failure

### DIFF
--- a/lib/ueberauth/strategy/twitter.ex
+++ b/lib/ueberauth/strategy/twitter.ex
@@ -105,13 +105,10 @@ defmodule Ueberauth.Strategy.Twitter do
       {:ok, %{status_code: 401, body: _, headers: _}} ->
         set_errors!(conn, [error("token", "unauthorized")])
       {:ok, %{status_code: status_code, body: body, headers: _}} when status_code in 200..399 ->
-        body = Ueberauth.json_library().decode!(body)
-
         conn
         |> put_private(:twitter_token, token)
         |> put_private(:twitter_user, body)
       {:ok, %{status_code: _, body: body, headers: _}} ->
-        body = Ueberauth.json_library().decode!(body)
         error = List.first(body["errors"])
         set_errors!(conn, [error("token", error["message"])])
     end

--- a/lib/ueberauth/strategy/twitter.ex
+++ b/lib/ueberauth/strategy/twitter.ex
@@ -101,13 +101,16 @@ defmodule Ueberauth.Strategy.Twitter do
 
   defp fetch_user(conn, token) do
     params = [{"include_entities", false}, {"skip_status", true}, {"include_email", true}]
+
     case Twitter.OAuth.get("/1.1/account/verify_credentials.json", params, token) do
       {:ok, %{status_code: 401, body: _, headers: _}} ->
         set_errors!(conn, [error("token", "unauthorized")])
+
       {:ok, %{status_code: status_code, body: body, headers: _}} when status_code in 200..399 ->
         conn
         |> put_private(:twitter_token, token)
         |> put_private(:twitter_user, body)
+
       {:ok, %{status_code: _, body: body, headers: _}} ->
         error = List.first(body["errors"])
         set_errors!(conn, [error("token", error["message"])])

--- a/lib/ueberauth/strategy/twitter/internal.ex
+++ b/lib/ueberauth/strategy/twitter/internal.ex
@@ -15,8 +15,26 @@ defmodule Ueberauth.Strategy.Twitter.OAuth.Internal do
       |> OAuther.sign(url, extraparams, creds)
       |> OAuther.header
 
-    HTTPoison.get(url, [header], params: params)
+    HTTPoison.get(url, [header, {"Accept", "application/json"}], params: params)
+    |> decode_body()
   end
+
+  def decode_body({:ok, response}) do
+    content_type = Enum.find_value(response.headers, fn
+      {"content-type", val} -> val
+      _ -> nil
+    end)
+    case content_type do
+      "application/json" <> _ ->
+        json_body = Ueberauth.json_library().decode!(response.body)
+        json_response = %{response | body: json_body}
+        {:ok, json_response}
+
+      _ ->
+        {:ok, response}
+    end
+  end
+  def decode_body(other), do: other
 
   def params_decode(resp) do
     resp

--- a/lib/ueberauth/strategy/twitter/internal.ex
+++ b/lib/ueberauth/strategy/twitter/internal.ex
@@ -20,10 +20,12 @@ defmodule Ueberauth.Strategy.Twitter.OAuth.Internal do
   end
 
   def decode_body({:ok, response}) do
-    content_type = Enum.find_value(response.headers, fn
-      {"content-type", val} -> val
-      _ -> nil
-    end)
+    content_type =
+      Enum.find_value(response.headers, fn
+        {"content-type", val} -> val
+        _ -> nil
+      end)
+
     case content_type do
       "application/json" <> _ ->
         json_body = Ueberauth.json_library().decode!(response.body)
@@ -34,6 +36,7 @@ defmodule Ueberauth.Strategy.Twitter.OAuth.Internal do
         {:ok, response}
     end
   end
+
   def decode_body(other), do: other
 
   def params_decode(resp) do

--- a/lib/ueberauth/strategy/twitter/oauth.ex
+++ b/lib/ueberauth/strategy/twitter/oauth.ex
@@ -80,8 +80,13 @@ defmodule Ueberauth.Strategy.Twitter.OAuth do
 
     {:ok, {token, token_secret}}
   end
-  defp decode_response({:ok, %{status_code: status_code, body: _, headers: _}}) do
-    {:error, "#{status_code}"}
+  defp decode_response({:ok, %{status_code: status_code, body: body, headers: _}}) do
+    message = String.replace(body, ~r/<.*?>/, "")
+    error_code = case Regex.scan(~r/<error code="(.*?)">/, body) do
+      [[_match, error_code]] -> error_code
+      _ -> nil
+    end
+    {:error, "#{message} (ERROR #{error_code}, STATUS #{status_code})"}
   end
   defp decode_response({:error, %{reason: reason}}) do
     {:error, "#{reason}"}

--- a/lib/ueberauth/strategy/twitter/oauth.ex
+++ b/lib/ueberauth/strategy/twitter/oauth.ex
@@ -85,19 +85,22 @@ defmodule Ueberauth.Strategy.Twitter.OAuth do
 
   defp consumer(client), do: {client.consumer_key, client.consumer_secret, :hmac_sha1}
 
-  defp decode_response({:ok, %{status_code: 200, body: body, headers: _}}) do
+  defp decode_response({:ok, %{status_code: 200, body: body}}) do
     params = Internal.params_decode(body)
     token = Internal.token(params)
     token_secret = Internal.token_secret(params)
 
     {:ok, {token, token_secret}}
   end
-  defp decode_response({:ok, %{status_code: status_code, body: %{"errors" => [error | _]}, headers: _}}) do
+
+  defp decode_response({:ok, %{status_code: status_code, body: %{"errors" => [error | _]}}}) do
     {:error, %ApiError{message: error["message"], code: error["code"]}}
   end
+
   defp decode_response({:error, %{reason: reason}}) do
     {:error, "#{reason}"}
   end
+
   defp decode_response(error) do
     {:error, error}
   end


### PR DESCRIPTION
Hi!

I've had problems with the app configuration on Twitter, and did not see proper error messages when using the OAuth modules. So I created an improved error message that formats the OAuth response as more readable exception message that is, in turn, rendered by Phoenix (or whatever you use).

Let me know whether this seems good & useful.