### PR TITLE
Forward query parameters to OAuth endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,10 @@ Depending on the configured url you can initiate the request through:
 
     /auth/twitter
 
+Query parameters such as `force_login` and `screen_name` will be forwarded to the [OAuth endpoint](https://developer.twitter.com/en/docs/basics/authentication/api-reference/authenticate). For example, to always ask for a user name and password (even if logged in to Twitter), initiate the request through:
+
+    /auth/twitter?force_login=true
+
 ## Development mode
 
 As noted when registering your application on the Twitter Developer site, you need to explicitly specify the `oauth_callback` url.  While in development, this is an example url you need to enter.

--- a/lib/ueberauth/strategy/twitter.ex
+++ b/lib/ueberauth/strategy/twitter.ex
@@ -18,7 +18,7 @@ defmodule Ueberauth.Strategy.Twitter do
 
     conn
     |> put_session(:twitter_token, token)
-    |> redirect!(Twitter.OAuth.authorize_url!(token))
+    |> redirect!(Twitter.OAuth.authorize_url!(token, auth_params: conn.query_params))
   end
 
   @doc """

--- a/lib/ueberauth/strategy/twitter/oauth.ex
+++ b/lib/ueberauth/strategy/twitter/oauth.ex
@@ -45,9 +45,13 @@ defmodule Ueberauth.Strategy.Twitter.OAuth do
   end
 
   def authorize_url!({token, _token_secret}, opts \\ []) do
+    {auth_params, opts} = Keyword.pop(opts, :auth_params, %{})
+
+    params = Map.put(auth_params, "oauth_token", token)
+
     opts
     |> client()
-    |> to_url(:authorize_url, %{"oauth_token" => token})
+    |> to_url(:authorize_url, params)
   end
 
   def client(opts \\ []) do


### PR DESCRIPTION
Twitter's OAuth authenticate endpoint supports query parameters `force_login` or `screen_name` to modify the user flow when authenticating with Twitter.

This change allows to make use of these parameters by forwarding all query parameters to the initial request to the OAuth endpoint.

For example, to always ask for a user name and password (even if logged in to Twitter), initiate the request through:

    /auth/twitter?force_login=true