### PR TITLE
Fix client config precedence

### DIFF
--- a/lib/ueberauth/strategy/twitter/oauth.ex
+++ b/lib/ueberauth/strategy/twitter/oauth.ex
@@ -54,8 +54,8 @@ defmodule Ueberauth.Strategy.Twitter.OAuth do
     config = Application.get_env(:ueberauth, __MODULE__)
 
     @defaults
-    |> Keyword.merge(config)
     |> Keyword.merge(opts)
+    |> Keyword.merge(config)
     |> Enum.into(%{})
   end
 

--- a/lib/ueberauth/strategy/twitter/oauth.ex
+++ b/lib/ueberauth/strategy/twitter/oauth.ex
@@ -55,9 +55,12 @@ defmodule Ueberauth.Strategy.Twitter.OAuth do
 
     @defaults
     |> Keyword.merge(opts)
-    |> Keyword.merge(config)
+    |> Keyword.merge(config, &merge_present_values/3)
     |> Enum.into(%{})
   end
+
+  defp merge_present_values(_key, left, nil), do: left
+  defp merge_present_values(_key, _left, right), do: right
 
   def get(url, access_token), do: get(url, [], access_token)
   def get(url, params, {token, token_secret}) do

--- a/lib/ueberauth/strategy/twitter/oauth.ex
+++ b/lib/ueberauth/strategy/twitter/oauth.ex
@@ -93,7 +93,7 @@ defmodule Ueberauth.Strategy.Twitter.OAuth do
     {:ok, {token, token_secret}}
   end
 
-  defp decode_response({:ok, %{status_code: status_code, body: %{"errors" => [error | _]}}}) do
+  defp decode_response({:ok, %{body: %{"errors" => [error | _]}}}) do
     {:error, %ApiError{message: error["message"], code: error["code"]}}
   end
 


### PR DESCRIPTION
Adding a `redirect_url` to the Application environment config didn't work as described in the README, because it was overridden by the default `callback_url` coming from the ueberauth helper. This change fixes the precedence, so the Application environment config precedes the default.