### PR TITLE
Disable CSRF protection

### DIFF
--- a/lib/ueberauth/strategy/twitter.ex
+++ b/lib/ueberauth/strategy/twitter.ex
@@ -3,7 +3,7 @@ defmodule Ueberauth.Strategy.Twitter do
   Twitter Strategy for Überauth.
   """
 
-  use Ueberauth.Strategy, uid_field: :id_str
+  use Ueberauth.Strategy, uid_field: :id_str, ignores_csrf_attack: true
 
   alias Ueberauth.Auth.Info
   alias Ueberauth.Auth.Credentials


### PR DESCRIPTION
While disabling CSRF protection isn't ideal of course, it will make this strategy work again.