### PR TITLE
Change Content-Type header key to properly parse json response

### DIFF
--- a/lib/ueberauth/strategy/twitter/internal.ex
+++ b/lib/ueberauth/strategy/twitter/internal.ex
@@ -26,7 +26,7 @@ defmodule Ueberauth.Strategy.Twitter.OAuth.Internal do
   def decode_body({:ok, response}) do
     content_type =
       Enum.find_value(response.headers, fn
-        {"content-type", val} -> val
+        {"Content-Type", val} -> val
         _ -> nil
       end)
 


### PR DESCRIPTION
Hey, I found an error that was causing the callback response not to be properly decoded.

It seems that the Twitter API changes the `content-type`response header to `Content-Type`. Causing the callback request handling to fail at detecting when was needed to decode the response body from json.

 